### PR TITLE
Put backup directory inside default PV location

### DIFF
--- a/postgresql-backup-persistent-template.json
+++ b/postgresql-backup-persistent-template.json
@@ -234,7 +234,7 @@
     }, {
         "name": "BACKUP_DATA_DIR",
         "description": "where to store the Backups, typically this directory would be a persistent Volume",
-        "value": "/var/lib/pgsql/backup",
+        "value": "/var/lib/pgsql/data/backup",
         "required": true
     }, {
         "name": "BACKUP_KEEP",


### PR DESCRIPTION
The default backup directory should be placed inside the mounted PV directory (which is hard coded to /var/lib/pgsql/data).
Of course this can be overwritten by setting the environment variable correctly, but to avoid a beginner's pitfall, it should be set to a reasonable default value that does not result in complete data loss on pod restart.